### PR TITLE
Fix/null protocols in db

### DIFF
--- a/src/scripts/populateDatabase.ts
+++ b/src/scripts/populateDatabase.ts
@@ -202,23 +202,6 @@ export async function populateDatabase(network: Network) {
       node.keyXdr === constants.instanceStorageKeyXdr
     ) {
       pairStorage++;
-      await prisma.subscriptions.upsert({
-        where: {
-          contractId_keyXdr: {
-            contractId: node.contractId,
-            keyXdr: node.keyXdr,
-          },
-          network,
-        },
-        update: {},
-        create: {
-          contractId: node.contractId,
-          keyXdr: node.keyXdr,
-          contractType: 'PAIR',
-          storageType: 'INSTANCE',
-          network,
-        },
-      });
     } else {
       others++;
     }


### PR DESCRIPTION
Currently ignoring pairs with instance keyXdr "AAAAFA==" & no protocols match on populateDB script